### PR TITLE
fix: prevent memory leak crash when PVS serial is an IP address

### DIFF
--- a/custom_components/sunpower/data_processor.py
+++ b/custom_components/sunpower/data_processor.py
@@ -46,18 +46,12 @@ def is_ip_address(serial):
 
 
 def generate_safe_virtual_serial(base_name, device_type):
-    """Generate a safe serial name that won't create zombies"""
-    import time
-    timestamp = int(time.time())
-    
-    # Create unique, non-IP serial names
-    safe_serial = f"{base_name}_{device_type.lower()}_{timestamp}"
-    
-    # Double-check it's not accidentally an IP
-    if is_ip_address(safe_serial):
-        # Extremely unlikely, but add extra suffix if needed
-        safe_serial = f"safe_{safe_serial}_virtual"
-    
+    """Generate a stable serial name for IP-based PVS devices.
+
+    Uses a fixed suffix instead of time.time() to avoid creating a new
+    entity on every poll cycle, which leaks memory and eventually crashes HA.
+    """
+    safe_serial = f"{base_name}_{device_type.lower()}_virtual"
     return safe_serial
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to the Enhanced SunPower Home Assistant Integration will be documented in this file.
 
 
+## [v2026.03.5] - 03-2026
+
+### Bug Fix: Memory Leak in IP-Based PVS Virtual Meter Naming
+
+**Fixed: Home Assistant crashes after ~31 hours of uptime when PVS uses an IP address as its serial**
+- **Problem**: When a PVS device reports an IP address as its serial number (common in some network configurations), `generate_safe_virtual_serial()` fell back to constructing the virtual meter entity name using `int(time.time())` as a suffix. Because this function is called on every poll cycle (~75 seconds), each poll created a brand-new HA entity with a unique name. HA's entity and device registries grew without bound, and long-term statistics rows accumulated in the SQLite database. After ~31 hours of operation this had produced 7,839 unique phantom device entries and 62,704 phantom entity entries; memory consumption reached 6.3 GB and Home Assistant terminated with a segmentation fault (exit code 139 / SIGSEGV).
+- **Impact**: Any installation where the PVS is addressed by IP (rather than a hardware serial) was silently leaking memory on every poll and would eventually crash Home Assistant. The registries and statistics database required manual cleanup to recover.
+- **Fix**: Replaced `int(time.time())` with a fixed `_virtual` suffix. The virtual meter serial is now `virtual_production_meter_meter_virtual` — stable across restarts and poll cycles — so HA maps all updates to the same entity rather than creating a new one each time.
+
+**Files Modified:**
+- `data_processor.py`: `generate_safe_virtual_serial()` uses a fixed `_virtual` suffix instead of `int(time.time())`
+
+---
+
 ## [v2026.03.4] - 03-2026
 
 ### Bug Fix: PVS5 Setup Failure


### PR DESCRIPTION
## Summary

- **Root cause**: `generate_safe_virtual_serial()` used `int(time.time())` as a suffix, so every poll cycle (~75s) created a brand-new HA entity name. Over time, HA's entity registry, device registry, and statistics database grew without bound.
- **Observed impact**: After ~31 hours of uptime, a PVS installation whose device reported an IP address as its serial had accumulated 7,839 phantom devices, 62,704 phantom entities, and consumed 6.3 GB of RAM before Home Assistant terminated with a segmentation fault (exit code 139 / SIGSEGV).
- **Fix**: Replace `int(time.time())` with a fixed `_virtual` suffix. The virtual meter serial is now `virtual_production_meter_meter_virtual` — stable across restarts and poll cycles.

## Affected installations

Any installation where the PVS reports an IP address as its serial number (the existing `is_ip_address()` path) rather than a hardware serial. The normal path (`{pvs_serial}pv`) was not affected.

## Recovery for existing affected users

Users who have already hit this bug will have orphaned entities in their registries and statistics database. After updating, the phantom entities will stop accumulating, but manual cleanup of existing entries is needed:

1. Stop Home Assistant
2. Use a script or HA's entity registry UI to remove entities matching `*_meter_<digits>` / `virtual_production_meter_meter_<unix_timestamp>`
3. Optionally vacuum the SQLite statistics database to reclaim space
4. Restart Home Assistant

## Test plan

- [ ] PVS with IP serial: confirm log shows `virtual_production_meter_meter_virtual` (not a timestamp) on every poll
- [ ] PVS with hardware serial: confirm existing `{pvs_serial}pv` path is unchanged
- [ ] Verify entity count in registry stays stable over multiple poll cycles

🤖 Generated with [Claude Code](https://claude.ai/claude-code)